### PR TITLE
add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,14 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-  - python: 2.7
+  - python: 3.5
     env: TEST_TARGET=default NUMPY=1.11
-  - python: 2.7
+  - python: 3.5
     env: TEST_TARGET=default NUMPY=1.12
   - python: 3.6
     env: TEST_TARGET=default NUMPY=1.11
   - python: 3.6
     env: TEST_TARGET=default NUMPY=1.12
-  - python: 3.6
-    env: TEST_TARGET=publish NUMPY=1.12
 
 before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh
@@ -32,5 +30,5 @@ install:
 
 script:
     - if [[ $TEST_TARGET == "default" ]]; then
-        python -c "import gsw; print(dir(gsw))" ;
+        cd /tmp && python -c "import gsw; print(dir(gsw))" ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: python
+
+sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+  - python: 2.7
+    env: TEST_TARGET=default NUMPY=1.11
+  - python: 2.7
+    env: TEST_TARGET=default NUMPY=1.12
+  - python: 3.6
+    env: TEST_TARGET=default NUMPY=1.11
+  - python: 3.6
+    env: TEST_TARGET=default NUMPY=1.12
+  - python: 3.6
+    env: TEST_TARGET=publish NUMPY=1.12
+
+before_install:
+    - wget http://bit.ly/miniconda -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - conda update conda --yes
+    - conda config --add channels conda-forge --force
+    - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION
+    - source activate TEST
+    # Install after to ensure it will be downgraded when testing an older version.
+    - conda install --yes --quiet numpy=$NUMPY
+
+install:
+    - python setup.py build && python setup.py install
+
+script:
+    - if [[ $TEST_TARGET == "default" ]]; then
+        python -c "import gsw; print(dir(gsw))" ;
+      fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include README.rst
+include README
 include LICENSE
-include src/c_gsw/LICENSE
+recursive-include src *
 include gsw/tests/*.npz
 # recursive-include docs *


### PR DESCRIPTION
@efiring I am keeping the PRs short to make it easier to review but I have another version of this that uses only `setuptools` `Extension` and makes the module more "consistent" with the recommended practices for packaging.

Even though I was able to build the package locally with `gcc 4.8.3` I was not able to make it work on `Travis-CI`'s `gcc`. I will take a better look tomorrow.