### PR TITLE
Unify READMEs and add Travis-CI badge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include README
 include LICENSE
+include README.rst
 recursive-include src *
 recursive-include src2 *
 include gsw/tests/*.npz

--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-This Python implementation of the Thermodynamic Equation of
-Seawater 2010 (TEOS-10) is based on numpy ufunc wrappers of
-the GSW-C implementation.

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,12 @@
 gswc
 ====
 
-This is the start of an *experimental* Python implementation
-of the Thermodynamic Equation Of Seawater - 2010
-(`TEOS-10 <http://www.teos-10.org/>`__) in which the *core*
-functionality is obtained by wrapping the functions from the
-C implementation (GSW-C).
+.. image:: https://travis-ci.org/efiring/python-gswc.svg?branch=master
+    :target: https://travis-ci.org/efiring/python-gswc
+
+This Python implementation of the Thermodynamic Equation of
+Seawater 2010 (TEOS-10) is based on numpy ufunc wrappers of
+the GSW-C implementation.
 
 **Warning: this is in an early development stage.  If it
 proceeds, the repo will probably be renamed and moved.**

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def extract_version():
     return version
 
 LICENSE = read('LICENSE')
-long_description = read('README')
+long_description = read('README.rst')
 
 config = dict(
     name='gsw',


### PR DESCRIPTION
@efiring I am not sure this change is desirable so feel free to close it if not.
I merged the two READMEs into one and added the Travis-CI badge.

I did not add AppVeyor's badge because it requires rights to the repo. 
If you want to add that you have to go to: https://ci.appveyor.com/project/efiring/python-gswc/settings/badges

But I don't think that is needed since all the URLs will change once we migrate the repository to TEOS-10.

PS: I did not see a run for the latest merge on https://travis-ci.org/efiring/python-gswc/branches
Not sure what happened but the docs won't be created without it. I will check this again tomorrow.